### PR TITLE
fix: should inherit default esbuild config

### DIFF
--- a/.changeset/strong-badgers-turn.md
+++ b/.changeset/strong-badgers-turn.md
@@ -1,0 +1,5 @@
+---
+"size-limit-node-esbuild": patch
+---
+
+fix: should inherit default esbuild config

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
   "node": "20",
-  "installCommand": "codesandbox:install",
   "sandboxes": []
 }

--- a/package.json
+++ b/package.json
@@ -81,11 +81,11 @@
   },
   "size-limit": [
     {
-      "path": "./packages/node-esbuild/lib/index.js",
-      "limit": "650B"
+      "path": "./packages/node-esbuild/src/index.ts",
+      "limit": "900B"
     },
     {
-      "path": "./packages/preset-node-lib/lib/index.js",
+      "path": "./packages/preset-node-lib/src/index.ts",
       "limit": "150B"
     }
   ],

--- a/packages/node-esbuild/src/index.ts
+++ b/packages/node-esbuild/src/index.ts
@@ -57,19 +57,25 @@ export default [
       if (!check.esbuildOutfile) {
         check.esbuildOutfile = path.join(tmpdir(), `size-limit-${nanoid()}`)
       }
+      const defaultEsbuildConfig = await getConfig(
+        config,
+        check,
+        check.esbuildOutfile,
+      )
       if (check.config) {
         const esbuildConfig = (await import(check.config)) as
           | BuildOptions
-          | { default: BuildOptions }
+          | { default?: BuildOptions }
         setPlatformNode(
           // eslint-disable-next-line sonarjs/no-nested-assignment
-          (check.esbuildConfig =
-            'default' in esbuildConfig ? esbuildConfig.default : esbuildConfig),
+          (check.esbuildConfig = {
+            ...defaultEsbuildConfig,
+            ...(('default' in esbuildConfig && esbuildConfig.default) ||
+              esbuildConfig),
+          }),
         )
       } else {
-        check.esbuildConfig = setPlatformNode(
-          await getConfig(config, check, check.esbuildOutfile),
-        )
+        check.esbuildConfig = setPlatformNode(defaultEsbuildConfig)
         if (check.modifyEsbuildConfig) {
           check.esbuildConfig = check.modifyEsbuildConfig(check.esbuildConfig)
         }


### PR DESCRIPTION
close #44
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes esbuild configuration inheritance to ensure default settings are maintained unless overridden by custom configurations.
> 
>   - **Bug Fix**:
>     - Ensure default esbuild configuration is inherited when custom configurations are provided in `index.ts`.
>   - **Refactor**:
>     - Improve merging logic of esbuild configurations in `index.ts`, prioritizing custom settings while maintaining defaults.
>   - **Misc**:
>     - Update `size-limit` paths in `package.json` to point to `src/index.ts` instead of `lib/index.js`.
>     - Remove `installCommand` from `.codesandbox/ci.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Fsize-limit&utm_source=github&utm_medium=referral)<sup> for 84b9ba677016a3d4d29cd16be5983c192c397835. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue to ensure the default esbuild configuration is properly inherited when custom configurations are provided.

- **Refactor**
  - Improved how esbuild configurations are merged, prioritizing custom settings while maintaining default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->